### PR TITLE
Always check absolute path defined before initializing plugin.

### DIFF
--- a/sj-timesheet.php
+++ b/sj-timesheet.php
@@ -11,4 +11,11 @@
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+/**
+ * If this file is called directly, abort.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
 require_once 'classes/class-sj-timesheet-loader.php';


### PR DESCRIPTION
This will help to make secure from invalid accessing.